### PR TITLE
feat: flutter - dependency no longer needed on main branch

### DIFF
--- a/docs/flutter.md
+++ b/docs/flutter.md
@@ -234,7 +234,7 @@ After pressing take picture, the live preview will appear.
 
 ## Troubleshooting
 
-### Failed resolution of: Lcom/ricoh360/thetaclient/ThetaRepository; (Flutter, Android)
+### Failed resolution of: Lcom/ricoh360/thetaclient/ThetaRepository; (Flutter, Android) when using theta-client version 1.0.0
 
 In `flutter_project_root/android/app/build.gradle`, specify `theta-client-debug.aar`
 in the dependencies.
@@ -243,7 +243,26 @@ in the dependencies.
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation files('../../packages/theta_client_flutter/android/aar/theta-client-debug.aar')
+}
+```
 
+As of April 2023, do not add add the line
+
+```groovy
+// line below is not needed as of April 2023.
+ implementation files('../../packages/theta_client_flutter/android/aar/theta-client-debug.aar')
+```
+
+In `demo-flutter/android/build.gradle`, add the line
+`mavenLocal()`
+
+```groovy
+allprojects {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
 }
 ```
 

--- a/docs/flutter/new-project-on-linux.md
+++ b/docs/flutter/new-project-on-linux.md
@@ -44,7 +44,10 @@ dependencies:
 
 ## configure Android build
 
-In `android/app/build.gradle`, make the following changes.
+This step is only needed in version 1.0.0.  As of April 5, 2023, do not add the local
+`aar` file to the dependencies if you cloned from the main branch.
+
+In `android/app/build.gradle`, make the following changes (only if used v1.0.0)
 
 ```groovy
 if (flutterRoot == null) {
@@ -57,6 +60,8 @@ defaultConfig {
     minSdkVersion 26
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    // only add the line below on v.1.0.0.  As of April 2023, it is not needed on the 
+    // main branch
     implementation files('../../packages/theta_client_flutter/android/aar/theta-client-debug.aar')    
 }    
 ```


### PR DESCRIPTION
mavenLocal() must be added to demo-flutter/android/build.gradle https://github.com/ricohapi/theta-client/issues/16#issuecomment-1493493539